### PR TITLE
Add ability to get courses by ID

### DIFF
--- a/sqrl/graphql/schema.py
+++ b/sqrl/graphql/schema.py
@@ -2,6 +2,7 @@ from typing import Any, Optional
 
 import graphene
 from graphene_mongo import MongoengineObjectType
+import mongoengine
 from flask import current_app
 
 from sqrl.models.common import Time
@@ -123,13 +124,15 @@ class Query(graphene.ObjectType):
     def resolve_courses_by_id(
             self, info: graphene.ResolveInfo, ids: list[str]) -> list[Course]:
         """Return a list of _CourseObject objects, each with given ids.
-        Courses that do not exist are ignored.
+        Courses that do not exist are null.
         """
         courses = []
         for id in ids:
-            course = Course.objects.get(id=id)
-            if course is not None:
+            try:
+                course = Course.objects.get(id=id)
                 courses.append(course)
+            except mongoengine.DoesNotExist:
+                courses.append(None)
         return courses
 
     def resolve_course_by_id(

--- a/sqrl/graphql/schema.py
+++ b/sqrl/graphql/schema.py
@@ -122,7 +122,9 @@ class Query(graphene.ObjectType):
 
     def resolve_courses_by_id(
             self, info: graphene.ResolveInfo, ids: list[str]) -> list[Course]:
-        """Return a _CourseObject object with the given id."""
+        """Return a list of _CourseObject objects, each with given ids.
+        Courses that do not exist are ignored.
+        """
         courses = []
         for id in ids:
             courses.append(Course.objects.get(id=id))

--- a/sqrl/graphql/schema.py
+++ b/sqrl/graphql/schema.py
@@ -127,7 +127,9 @@ class Query(graphene.ObjectType):
         """
         courses = []
         for id in ids:
-            courses.append(Course.objects.get(id=id))
+            course = Course.objects.get(id=id)
+            if course is not None:
+                courses.append(course)
         return courses
 
     def resolve_course_by_id(

--- a/sqrl/graphql/schema.py
+++ b/sqrl/graphql/schema.py
@@ -93,6 +93,8 @@ class Query(graphene.ObjectType):
     )
     organisations = graphene.ConnectionField(_OrganisationObjectConnection)
 
+    courses_by_id = graphene.List(
+        _CourseObject, ids=graphene.NonNull(graphene.List(graphene.NonNull(graphene.String))))
     course_by_id = graphene.Field(
         _CourseObject, id=graphene.String(required=True))
     courses = graphene.ConnectionField(_CourseObjectConnection)
@@ -117,6 +119,14 @@ class Query(graphene.ObjectType):
     ) -> list[Organisation]:
         """Return a list of _OrganisationObject objects."""
         return list(Organisation.objects.all())
+
+    def resolve_courses_by_id(
+            self, info: graphene.ResolveInfo, ids: list[str]) -> list[Course]:
+        """Return a _CourseObject object with the given id."""
+        courses = []
+        for id in ids:
+            courses.append(Course.objects.get(id=id))
+        return courses
 
     def resolve_course_by_id(
             self, info: graphene.ResolveInfo, id: str) -> Course:


### PR DESCRIPTION
Add a query for `getCoursesById`, whereby a client can request a more than one course by ID, instead of sending a request for each course.